### PR TITLE
Update test.yml remove macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
           - { os: ubuntu-22.04 }
           - { os: macos-15 }
           - { os: macos-14 }
-          - { os: macos-13 }
           - { os: windows-2025 }
           - { os: windows-2022 }
     steps:


### PR DESCRIPTION
 macOS 13 runner image will be retired by December 4th, 2025.